### PR TITLE
Typed decoder factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,14 @@ cd ~/ws
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo  # (optionally add -DCMAKE_EXPORT_COMPILE_COMMANDS=1)
 ```
 
-## API example
+## API example (ROS2)
 
 ```cpp
 #include <event_camera_codecs/decoder.h>
 #include <event_camera_codecs/decoder_factory.h>
+#include <event_camera_msgs/msgs/event_packet.hpp>
+
+using EventPacket = event_camera_msgs::EventPacket;
 
 class MyProcessor : public event_camera_codecs::EventProcessor
 {
@@ -63,12 +66,12 @@ MyProcessor processor;
 // the decoder factory method is templated on the event processor
 // to permit inlining of methods like eventCD() above.
 
-event_camera_codecs::DecoderFactory<MyProcessor> decoderFactory;
+event_camera_codecs::DecoderFactory<EventPacket, MyProcessor> decoderFactory;
 
 // to get callbacks into MyProcessor, feed the message buffer
 // into the decoder
 
-void eventMsg(const EventArray::ConstPtr & msg) {
+void eventMsg(const EventPacket::ConstSharedPtr & msg) {
   // will create a new decoder on first call, from then on returns existing one
   auto decoder = decoderFactory.getInstance(msg->encoding, msg->width, msg->height);
   if (!decoder) { // msg->encoding was invalid

--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo  #
 ```cpp
 #include <event_camera_codecs/decoder.h>
 #include <event_camera_codecs/decoder_factory.h>
-#include <event_camera_msgs/msgs/event_packet.hpp>
 
-using EventPacket = event_camera_msgs::EventPacket;
+using event_camera_codecs::EventPacket;
 
 class MyProcessor : public event_camera_codecs::EventProcessor
 {

--- a/cmake/ROS2.cmake
+++ b/cmake/ROS2.cmake
@@ -40,6 +40,7 @@ target_include_directories(codec
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
+ament_target_dependencies(codec ${ROS2_DEPENDENCIES})
 ament_export_targets(codecTargets HAS_LIBRARY_TARGET)
 ament_export_dependencies(${ROS2_DEPENDENCIES})
 

--- a/include/event_camera_codecs/decoder.h
+++ b/include/event_camera_codecs/decoder.h
@@ -21,13 +21,17 @@
 
 #ifdef USING_ROS_1
 #include <event_camera_msgs/EventPacket.h>
-namespace event_camera_codecs {
-  using EventPacket = event_camera_msgs::EventPacket;
+
+namespace event_camera_codecs
+{
+using EventPacket = event_camera_msgs::EventPacket;
 }
 #else
 #include <event_camera_msgs/msg/event_packet.hpp>
-namespace event_camera_codecs {
-  using EventPacket = event_camera_msgs::msg::EventPacket;
+
+namespace event_camera_codecs
+{
+using EventPacket = event_camera_msgs::msg::EventPacket;
 }
 #endif
 

--- a/include/event_camera_codecs/decoder.h
+++ b/include/event_camera_codecs/decoder.h
@@ -19,7 +19,18 @@
 #include <event_camera_codecs/noop_event_processor.h>
 #include <stdint.h>
 
+#ifdef USING_ROS_1
+#include <event_camera_msgs/EventPacket.h>
+namespace event_camera_codecs {
+  using EventPacket = event_camera_msgs::EventPacket;
+}
+#else
 #include <event_camera_msgs/msg/event_packet.hpp>
+namespace event_camera_codecs {
+  using EventPacket = event_camera_msgs::msg::EventPacket;
+}
+#endif
+
 #include <memory>
 #include <string>
 

--- a/include/event_camera_codecs/decoder.h
+++ b/include/event_camera_codecs/decoder.h
@@ -19,12 +19,13 @@
 #include <event_camera_codecs/noop_event_processor.h>
 #include <stdint.h>
 
+#include <event_camera_msgs/msg/event_packet.hpp>
 #include <memory>
 #include <string>
 
 namespace event_camera_codecs
 {
-template <class EventProcT = NoOpEventProcessor>
+template <class MsgT, class EventProcT = NoOpEventProcessor>
 class Decoder
 {
 public:

--- a/include/event_camera_codecs/decoder_factory.h
+++ b/include/event_camera_codecs/decoder_factory.h
@@ -23,7 +23,6 @@
 #include <event_camera_codecs/trigger_decoder.h>
 #include <stdint.h>
 
-#include <event_camera_msgs/msg/event_packet.hpp>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -50,10 +49,9 @@ public:
 };
 
 template <class EventProcT>
-class DecoderFactory<event_camera_msgs::msg::EventPacket, EventProcT>
+class DecoderFactory<EventPacket, EventProcT>
 {
 public:
-  using EventPacket = event_camera_msgs::msg::EventPacket;
   std::shared_ptr<Decoder<EventPacket, EventProcT>> newInstance(const std::string & codec)
   {
     if (codec == "evt3") {

--- a/include/event_camera_codecs/evt3_decoder.h
+++ b/include/event_camera_codecs/evt3_decoder.h
@@ -30,8 +30,8 @@ namespace event_camera_codecs
 {
 namespace evt3
 {
-template <class EventProcT>
-class Decoder : public event_camera_codecs::Decoder<EventProcT>
+template <class MsgT, class EventProcT>
+class Decoder : public event_camera_codecs::Decoder<MsgT, EventProcT>
 {
 public:
   using timestamp_t = uint64_t;

--- a/include/event_camera_codecs/mono_decoder.h
+++ b/include/event_camera_codecs/mono_decoder.h
@@ -28,8 +28,8 @@ namespace event_camera_codecs
 {
 namespace mono
 {
-template <class EventProcT>
-class Decoder : public event_camera_codecs::Decoder<EventProcT>
+template <class MsgT, class EventProcT>
+class Decoder : public event_camera_codecs::Decoder<MsgT, EventProcT>
 {
 public:
   using timestamp_t = uint64_t;

--- a/include/event_camera_codecs/trigger_decoder.h
+++ b/include/event_camera_codecs/trigger_decoder.h
@@ -28,8 +28,8 @@ namespace event_camera_codecs
 {
 namespace trigger
 {
-template <class EventProcT>
-class Decoder : public event_camera_codecs::Decoder<EventProcT>
+template <class MsgT, class EventProcT>
+class Decoder : public event_camera_codecs::Decoder<MsgT, EventProcT>
 {
 public:
   using timestamp_t = uint64_t;

--- a/src/perf.cpp
+++ b/src/perf.cpp
@@ -23,8 +23,6 @@
 #include "event_camera_codecs/decoder_factory.h"
 #include "event_camera_codecs/event_processor.h"
 
-using EventPacket = event_camera_msgs::msg::EventPacket;
-
 void usage()
 {
   std::cout << "usage:" << std::endl;
@@ -118,7 +116,7 @@ int main(int argc, char ** argv)
 
   std::vector<char> buffer(bufferSize);
   EventCounter counter;
-  event_camera_codecs::DecoderFactory<EventPacket, EventCounter> factory;
+  event_camera_codecs::DecoderFactory<event_camera_codecs::EventPacket, EventCounter> factory;
   auto decoder = factory.newInstance(codec);
   if (!decoder) {
     std::cout << "unknown codec: " << codec << std::endl;

--- a/src/perf.cpp
+++ b/src/perf.cpp
@@ -23,6 +23,8 @@
 #include "event_camera_codecs/decoder_factory.h"
 #include "event_camera_codecs/event_processor.h"
 
+using EventPacket = event_camera_msgs::msg::EventPacket;
+
 void usage()
 {
   std::cout << "usage:" << std::endl;
@@ -116,7 +118,7 @@ int main(int argc, char ** argv)
 
   std::vector<char> buffer(bufferSize);
   EventCounter counter;
-  event_camera_codecs::DecoderFactory<EventCounter> factory;
+  event_camera_codecs::DecoderFactory<EventPacket, EventCounter> factory;
   auto decoder = factory.newInstance(codec);
   if (!decoder) {
     std::cout << "unknown codec: " << codec << std::endl;


### PR DESCRIPTION
This commit breaks the API. Going forward the decoder and decoder_factory are typed. This is done to make the API more flexible if different message types must be supported in the future