### PR TITLE
fix bug in libcaer timeMult

### DIFF
--- a/include/event_camera_codecs/libcaer_cmp_decoder.h
+++ b/include/event_camera_codecs/libcaer_cmp_decoder.h
@@ -208,7 +208,7 @@ public:
 private:
   inline timestamp_t makeTime(timestamp_t high, uint16_t low)
   {
-    const timestamp_t t = ((high | low) + timeBase_) * timeMult_;
+    const timestamp_t t = (high | low) * timeMult_ + timeBase_;
     return (t);
   }
 


### PR DESCRIPTION
This commit fixes a bug with the libcaer decoder that bites when timeMult_ is not set to 1.
